### PR TITLE
Adds trap to `sensor_adaptor.go()` method

### DIFF
--- a/Adapters.indigoPlugin/Contents/Info.plist
+++ b/Adapters.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2022.1.0</string>
+	<string>2022.1.8</string>
 	<key>ServerApiVersion</key>
 	<string>3.0</string>
 	<key>IwsApiVersion</key>

--- a/Adapters.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -14,7 +14,7 @@ __copyright__ = "Not used."
 __license__   = "Apache 2.0"  # FIXME - update to a more appropriate license
 __build__     = "Not used."
 __title__     = 'Adapters Plugin for Indigo'
-__version__   = '2022.0.7'
+__version__   = '2022.1.8'
 
 
 # ==============================================================================

--- a/Adapters.indigoPlugin/Contents/Server Plugin/sensor_adapter.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/sensor_adapter.py
@@ -56,20 +56,24 @@ class SensorAdapter:
         """
         Docstring placeholder
         """
-        native_value = indigo.devices[self.native_device_id].states[self.native_device_state_name]
+        try:
+            native_value = indigo.devices[self.native_device_id].states[self.native_device_state_name]
 
-        converted_txt = self.desired_scale.format(native_value)
-        converted_value = self.desired_scale.convert(native_value)
+            converted_txt = self.desired_scale.format(native_value)
+            converted_value = self.desired_scale.convert(native_value)
 
-        self.dev.updateStateOnServer(
-            key="sensorValue",
-            value=converted_value,
-            decimalPlaces=self.precision,
-            uiValue=converted_txt
-        )
-        self.logging.debug(f" {self.name()}  converted to: [ {converted_txt} ]")
+            self.dev.updateStateOnServer(
+                key="sensorValue",
+                value=converted_value,
+                decimalPlaces=self.precision,
+                uiValue=converted_txt
+            )
+            self.logging.debug(f" {self.name()}  converted to: [ {converted_txt} ]")
 
-        return converted_txt
+            return converted_txt
+
+        except KeyError:
+            pass
 
 # ==============================================================================
 class _PredefinedDelegate:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ This plugin for the Indigo home automation sever allows you to add thin "adapter
 For example, suppose you have devices that report temperatures in Fahrenheit and you prefer Celsius, or the other way around. This plugin can generate "device adapters" that "wrap" around your native device and convert the temperature to the scale you prefer.
 
 It supports all kinds of things:
-* temperature, distance, and power conversions
-* arbitrary linear translations of numeric sensors (i.e. multiplier and an offset factor)
-* custom expressions and formats to transmogrify (single) sensor outputs in almost any way you can think of
+- temperature, distance, and power conversions
+- arbitrary linear translations of numeric sensors (i.e. multiplier and an offset factor)
+- custom expressions and formats to transmogrify (single) sensor outputs in almost any way you can think of
+
+Recent changes to this plugin include:
+- Direct support for Indigo 2022 and Python 3.
+- New tool in device configuration dialogs to select custom icon in the Indigo UI.
+- New tool to test formula expressions before saving them to the device.
+- Removes Rankine and Kelvin from temperature conversions.
+- Adds UI icons to devices lacking them; improves state value alignment in the Indigo UI.

--- a/_changelog.md
+++ b/_changelog.md
@@ -1,3 +1,6 @@
+### 2022.1.8
+- Adds trap to `sensor_adaptor.go()` method to avoid infrequent tracebacks when devices not available at startup.
+
 ### 2022.1.0
 - plugin store release 
 


### PR DESCRIPTION
Adds trap to `sensor_adaptor.go()` method to avoid infrequent tracebacks when devices not available at startup.