### PR TITLE
Code testing and clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 .*
 *.pyc
-nest.plugin.py
 plugin-dir
 *.sh
-get_thermostats_sample_response.json
-get_thermostats_sample_response_2.json
-test.py
+/adapters.wiki/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 plugin-dir
 *.sh
 /adapters.wiki/.idea/
-/Adapters.indigoPlugin/Contents/Server Plugin/requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 plugin-dir
 *.sh
 /adapters.wiki/.idea/
+/Adapters.indigoPlugin/Contents/Server Plugin/requirements.txt

--- a/Adapters.indigoPlugin/Contents/Info.plist
+++ b/Adapters.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>2023.2.0</string>
+	<string>2024.1.0</string>
 	<key>ServerApiVersion</key>
 	<string>3.2</string>
 	<key>CFBundleDisplayName</key>

--- a/Adapters.indigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/Actions.xml
@@ -1,3 +1,8 @@
 <?xml version="1.0"?>
 <Actions>
+    <!-- To support unit testing. -->
+    <Action id="my_tests" uiPath="hidden">
+        <Name>My Tests</Name>
+        <CallbackMethod>my_tests</CallbackMethod>
+    </Action>
 </Actions>

--- a/Adapters.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -34,7 +34,7 @@
 					<Option value="3">1.000</Option>
 				</List>
 			</Field>
-			<Field id="SupportsSensorValue" type="textfield" hidden="True" defaultValue="True"/>
+			<Field id="SupportsSensorValue" type="textfield" hidden="true" defaultValue="True"/>
 			<Field id="SupportsStatusRequest" type="textfield" hidden="true" defaultValue="False"/>
 			<Field id="SupportsOnState" type="textfield" hidden="true" defaultValue="False"/>
 		</ConfigUI>
@@ -78,7 +78,7 @@
 		    <Title>Formatting Help</Title>
 		    <CallbackMethod>open_browser_to_python_format_help</CallbackMethod>
 		  	</Field>
-			<Field id="SupportsSensorValue" type="textfield" hidden="True" defaultValue="True"/>
+			<Field id="SupportsSensorValue" type="textfield" hidden="true" defaultValue="True"/>
 			<Field id="SupportsStatusRequest" type="textfield" hidden="true" defaultValue="False"/>
 			<Field id="SupportsOnState" type="textfield" hidden="true" defaultValue="False"/>
 		</ConfigUI>
@@ -131,7 +131,7 @@
 				<Title>Formatting Help</Title>
 				<CallbackMethod>open_browser_to_python_format_help</CallbackMethod>
 			</Field>
-			<Field id="SupportsSensorValue" type="textfield" hidden="True" defaultValue="True"/>
+			<Field id="SupportsSensorValue" type="textfield" hidden="true" defaultValue="True"/>
 			<Field id="SupportsStatusRequest" type="textfield" hidden="true" defaultValue="False"/>
 			<Field id="SupportsOnState" type="textfield" hidden="true" defaultValue="False"/>
 		</ConfigUI>

--- a/Adapters.indigoPlugin/Contents/Server Plugin/Tests/__init__.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/Tests/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['test_plugin', 'test_xml']

--- a/Adapters.indigoPlugin/Contents/Server Plugin/Tests/test_plugin.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/Tests/test_plugin.py
@@ -1,0 +1,115 @@
+"""
+Unit tests that require access to the IOM go here.
+
+Tests should be added to this file when appropriate.
+"""
+from unittest import TestCase
+# from unittest.mock import MagicMock
+import dotenv
+import logging
+import indigo  # noqa
+import os
+
+
+import simpleeval  # noqa
+# import sensor_adapter  # noqa
+import pyrescaler  # noqa
+
+LOGGER = logging.getLogger('Plugin')
+dotenv.load_dotenv()
+
+DEVICE_CUSTOM_FORMULA_GENERIC = indigo.devices[int(os.getenv('DEVICE_CUSTOM_FORMULA_GENERIC'))]
+DEV_TEMP_CONV = indigo.devices[int(os.getenv('DEVICE_TEMPERATURE_CONVERSION'))]
+
+
+class TestPlugin(TestCase):
+    """ """
+    def __init__(self):
+        super().__init__()
+
+    @staticmethod
+    def test_plugin(plugin):
+        """ """
+        try:
+            test_case = TestCase()
+
+            # ===================================== validate_prefs_config_ui() =====================================
+            values_dict = {'showDebugLevel': '20'}  # value as string
+            test_case.assertTrue(plugin.validate_prefs_config_ui(values_dict), "Method should return True.")
+            values_dict['showDebugLevel'] = 20  # value as int
+            test_case.assertTrue(plugin.validate_prefs_config_ui(values_dict), "Method should return True.")
+
+            # ===================================== show_formula_result() =====================================
+            value = DEV_TEMP_CONV.states['temperature']  # value as real
+            values_dict = {'address': f"{DEV_TEMP_CONV.id}.temperature", 'format': "{0:.2f} ºF", 'multiplier': "", 'offset': "", 'formula': "x / 2"}
+            result = plugin.show_formula_result(values_dict, "", 0)
+            test_case.assertIsInstance(result, dict, "Method should return a dict object.")
+            test_case.assertIsInstance(result['formula_test'], str, "Method should return a string object.")
+            test_case.assertEqual(result['formula_test'], f'{value / 2} ºF', "Method didn't return a properly formatted value.")
+
+            # ===================================== get_scales() =====================================
+            values_dict = {}
+            scale_list = {'power': [('W', 'Watts'), ('kW', 'Kilowatts'), ('hp', 'Horsepower')],
+                          'temperature': [('F', 'Fahrenheit'), ('C', 'Celsius')],
+                          'length': [('in', 'Inches'), ('ft', 'Feet'), ('yd', 'Yards'), ('mi', 'Miles'), ('cm', 'Centimeters'), ('m', 'Meters'), ('km', 'Kilometers'), ('nmi', 'Nautical Miles'), ('fm', 'Fathoms'), ('cbt', 'Cubits'), ('h', 'Hands')],
+                          '': [],
+                          }
+            result = plugin.get_scales("", values_dict, "", 0)
+            test_case.assertIsInstance(result, list, "Method should return a list object.")
+            for scale_type in ['power', 'temperature', 'length', '']:
+                values_dict = {'scaleType': scale_type}
+                result = plugin.get_scales("", values_dict, "", 0)
+                test_case.assertIsInstance(result, list, "Method should return a list object.")
+                test_case.assertEqual(result, scale_list[scale_type], "Method didn't return a valid list.")
+
+            # ===================================== get_eligible_sensors() =====================================
+            # We can't test if get_eligible_sensors() returns an accurate list because the result can vary.
+            result = plugin.get_eligible_sensors("", None, "", 0)
+            test_case.assertIsInstance(result, list, "Method should return a list object.")
+            test_case.assertTrue(all(isinstance(item, tuple) for item in result), "List should contain only tuples.")
+
+            return True, None
+        except Exception as error:
+            LOGGER.critical(f"{error}")
+            return False, error
+
+
+# ===================================== simpleeval.py =====================================
+class TestSimpleEval(TestCase):
+    def __init__(self):
+        super().__init__()
+
+    @staticmethod
+    def test_simple_eval(plugin):
+        test_case = TestCase()
+        # ===================================== random_int() =====================================
+        test_case.assertTrue(simpleeval.random_int(10) <= 10, "Method return should be less than input")
+        test_case.assertTrue(simpleeval.random_int(100) <= 100, "Method return should be less than input")
+
+        # ===================================== safe_power() =====================================
+        test_case.assertEqual(simpleeval.safe_power(2, 4), 16, "Method didn't return the expected value.")
+
+        # ===================================== safe_multi() =====================================
+        test_case.assertEqual(simpleeval.safe_mult(10, "*"), "**********", "Method didn't return the expected value.")
+        test_case.assertEqual(simpleeval.safe_mult(10, 2), 20, "Method didn't return the expected value.")
+
+        # ===================================== safe_add() =====================================
+        test_case.assertEqual(simpleeval.safe_add("**", "**"), "****", "Method didn't return the expected value.")
+        test_case.assertEqual(simpleeval.safe_add(1, 1), 2, "Method didn't return the expected value.")
+
+        # ===================================== simple_eval() =====================================
+        test_case.assertEqual(simpleeval.simple_eval('x', None, None, {'x': 50}), 50, "Method didn't return the expected value.")
+        test_case.assertEqual(simpleeval.simple_eval('x + 2', None, None, {'x': 50}), 52, "Method didn't return the expected value.")
+        test_case.assertEqual(simpleeval.simple_eval('x - 2', None, None, {'x': 50}), 48, "Method didn't return the expected value.")
+        test_case.assertEqual(simpleeval.simple_eval('x * 2', None, None, {'x': 50}), 100, "Method didn't return the expected value.")
+        test_case.assertEqual(simpleeval.simple_eval('x / 2', None, None, {'x': 50}), 25, "Method didn't return the expected value.")
+        test_case.assertEqual(simpleeval.simple_eval('x + 20 - (10 * 7)', None, None, {'x': 50}), 0, "Method didn't return the expected value.")
+        test_case.assertEqual(simpleeval.simple_eval('x ** 2', None, None, {'x': 5}), 25, "Method didn't return the expected value.")
+        test_case.assertEqual(simpleeval.simple_eval('1 if x == 2 else -1 if x == 3 else 0', None, None, {'x': 2}), 1, "Method didn't return the expected value.")
+        test_case.assertEqual(simpleeval.simple_eval('1 if x == 2 else -1 if x == 3 else 0', None, None, {'x': 3}), -1, "Method didn't return the expected value.")
+        test_case.assertEqual(simpleeval.simple_eval('1 if x == 2 else -1 if x == 3 else 0', None, None, {'x': 4}), 0, "Method didn't return the expected value.")
+        return True, None
+
+
+# ===================================== sensor_adapter.py =====================================
+# There are no sensor_adapter tests at this time. They should be added as need cases arise.

--- a/Adapters.indigoPlugin/Contents/Server Plugin/Tests/test_plugin.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/Tests/test_plugin.py
@@ -1,6 +1,20 @@
 """
 Unit tests that require access to the IOM go here.
 
+To run these tests, you will need a copy of the plugin installed and running on the active server. Create an action item
+that calls the hidden `my_tests` action using an embedded script like the following:
+
+    plugin_id = "com.drjason.temp-adapter"
+    plugin = indigo.server.getPlugin(plugin_id)
+
+    try:
+        if indigo.PluginInfo.isRunning(plugin):
+            plugin.executeAction("my_tests")
+        else:
+            indigo.server.log("Plugin not enabled.")
+    except Exception as err:
+        indigo.server.log(f"{err}")
+
 Tests should be added to this file when appropriate.
 """
 from unittest import TestCase

--- a/Adapters.indigoPlugin/Contents/Server Plugin/Tests/test_plugin.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/Tests/test_plugin.py
@@ -45,7 +45,7 @@ class TestPlugin(TestCase):
             result = plugin.show_formula_result(values_dict, "", 0)
             test_case.assertIsInstance(result, dict, "Method should return a dict object.")
             test_case.assertIsInstance(result['formula_test'], str, "Method should return a string object.")
-            test_case.assertEqual(result['formula_test'], f'{value / 2} ºF', "Method didn't return a properly formatted value.")
+            test_case.assertEqual(result['formula_test'], f'{value / 2:0.2f} ºF', "Method didn't return a properly formatted value.")
 
             # ===================================== get_scales() =====================================
             values_dict = {}

--- a/Adapters.indigoPlugin/Contents/Server Plugin/Tests/test_xml.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/Tests/test_xml.py
@@ -1,0 +1,129 @@
+"""
+Test Plugin XML files for format and content
+
+The test_xml file tests the XML files located in the plugin package for format and content and will flag entries that
+are incomplete or don't comport with XML (and Indigo) conventions. These tests do not require access to the Indigo IOM,
+can be run from an IDE, and do not require the plugin to be installed or enabled. The files tested are listed in the
+setUpClass method below. The tests include checks for required elements (like element `id` and `type` attributes) and
+syntax.
+
+The code below may need to be modified to run on different environments (specifically, references to where the files
+are stored) within an IDE or from the command line. Using the BASE_PATH variable in .env makes this easier.
+
+For example, in Terminal run this test with:
+    > cd <path/to/test/folder/>
+    > export PYTHONPATH=/path/to/your/repo/Adapters.indigoPlugin/Contents/Server\ Plugin
+    > python -m unittest test_xml
+
+The change to the PYTHONPATH in Terminal will revert when Terminal is closed (or you reset it).
+"""
+import dotenv
+from unittest import TestCase
+from indigo_devices_filters import DEVICE_FILTERS
+from httpcodes import codes as httpcodes
+import httpx
+import os
+import xml.etree.ElementTree as ET  # noqa
+
+
+dotenv.load_dotenv()
+BASE_PATH = os.getenv('BASE_PATH')
+
+
+class TestXml(TestCase):
+    """
+    The TestXml class is used to test the various XML files that are part of a standard Indigo plugin.
+
+    The files tested are listed in the setUpClass method below. The tests include checks for required elements (like
+    element `id` and `type` attributes) and syntax.
+    """
+    @classmethod
+    def setUpClass(cls):
+        cls.xml_files   = [f'{BASE_PATH}/Actions.xml', f'{BASE_PATH}/MenuItems.xml', f'{BASE_PATH}/Devices.xml', f'{BASE_PATH}/Events.xml']
+        cls.field_types = ['button', 'checkbox', 'colorpicker', 'label', 'list', 'menu', 'separator', 'textfield']
+        # Load the plugin.py code into a var for testing later.
+        with open(f'{BASE_PATH}/plugin.py', 'r') as infile:
+            cls.plugin_lines = infile.read()
+
+    @staticmethod
+    def get_item_name(xml_file: str, item_id: int):
+        tree = ET.parse(xml_file)
+        return tree.getroot()
+
+    def test_xml_files(self):
+        try:
+            for file_type in self.xml_files:
+                try:
+                    root = self.get_item_name(file_type, 0)
+                except FileNotFoundError:
+                    print(f"\"{file_type}\" file not present.")
+                    continue
+                for item in root:
+                    # Test the 'id' attribute (required):
+                    node_id = item.get('id')
+                    self.assertIsNotNone(node_id,
+                                         f"\"{file_type}\" element \"{item.tag}\" attribute 'id' is required.")
+                    self.assertIsInstance(node_id, str, "id names must be strings.")
+                    self.assertNotIn(' ', node_id, f"`id` names should not contain spaces.")
+
+                    # Test the 'deviceFilter' attribute:
+                    dev_filter = item.get('deviceFilter', "")
+                    self.assertIsInstance(dev_filter, str, "`deviceFilter` values must be strings.")
+                    if dev_filter:  # None if not specified in item attributes
+                        self.assertIn(dev_filter, DEVICE_FILTERS, "'deviceFilter' values must be strings.")
+
+                    # Test the 'uiPath' attribute. It can be essentially anything as long as it's a string.
+                    ui_path = item.get('uiPath', "")
+                    self.assertIsInstance(ui_path, str, "uiPath names must be strings.")
+
+                # Test items that have a 'Name' element. The reference to `root.tag[:-1]` takes the tag name and
+                # converts it to the appropriate child element name. For example, `Actions` -> `Action`, etc.
+                for thing in root.findall(f"./{root.tag[:-1]}/Name"):
+                    self.assertIsInstance(thing.text, str, "Action names must be strings.")
+
+                # Test items that have a 'CallBackMethod` element:
+                for thing in root.findall(f"./{root.tag[:-1]}/CallbackMethod"):
+                    self.assertIsInstance(thing.text, str, "Action callback names must be strings.")
+                    # We can't directly access the plugin.py file from here, so we read it into a variable instead.
+                    # We then search for the string `def <CALLBACK METHOD>` within the file as a proxy to doing a
+                    # `dir()` to see if it's in there.
+                    self.assertTrue(f"def {thing.text}" in self.plugin_lines,
+                                    f"The callback method \"{thing.text}\" does not exist in the plugin.py file.")
+
+                # Test items that have a 'configUI' element
+                for thing in root.findall(f"./{root.tag[:-1]}/ConfigUI/SupportURL"):
+                    self.assertIsInstance(thing.text, str, "Config UI support URLs must be strings.")
+                    result = httpx.get(thing.text).status_code
+                    self.assertEqual(result, 200,
+                                     f"ERROR: Got status code {result} -> {httpcodes[result]}.")
+
+                # Test Config UI `Field` elements
+                for thing in root.findall(f"./{root.tag[:-1]}/ConfigUI/Field"):
+                    # Required attributes. Will throw a KeyError if missing.
+                    self.assertIsInstance(thing.attrib['id'], str, "Config UI field IDs must be strings.")
+                    self.assertFalse(thing.attrib['id'] == "", "Config UI field IDs must not be an empty string.")
+                    self.assertIsInstance(thing.attrib['type'], str, "Config UI field types must be strings.")
+                    self.assertIn(thing.attrib['type'], self.field_types,
+                                  f"Config UI field types must be one of {self.field_types}.")
+                    # Optional attributes
+                    self.assertIsInstance(thing.attrib.get('defaultValue', ""), str,
+                                          "Config UI defaultValue types must be strings.")
+                    self.assertIsInstance(thing.attrib.get('enabledBindingId', ""), str,
+                                          "Config UI enabledBindingId types must be strings.")
+                    self.assertIsInstance(thing.attrib.get('enabledBindingNegate', ""), str,
+                                          "Config UI enabledBindingNegate types must be strings.")
+                    self.assertIn(thing.attrib.get('hidden', "false"), ['true', 'false'],
+                                  f"Config UI hidden attribute must be 'true' or 'false'.")
+                    self.assertIn(thing.attrib.get('readonly', "false"), ['true', 'false'],
+                                  f"Config UI readonly attribute must be 'true' or 'false'.")
+                    self.assertIn(thing.attrib.get('secure', "false"), ['true', 'false'],
+                                  f"Config UI secure attribute must be 'true' or 'false'.")
+                    self.assertIsInstance(thing.attrib.get('tooltip', ""), str,
+                                          "Config UI field tool tips must be strings.")
+                    self.assertIsInstance(thing.attrib.get('visibleBindingId', ""), str,
+                                          "Config UI visibleBindingId types must be strings.")
+                    self.assertIsInstance(thing.attrib.get('visibleBindingValue', ""), str,
+                                          "Config UI visibleBindingValue types must be strings.")
+
+        except AssertionError as err:
+            print(f"ERROR: {self._testMethodName}: {err}")

--- a/Adapters.indigoPlugin/Contents/Server Plugin/httpcodes.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/httpcodes.py
@@ -1,0 +1,84 @@
+"""
+httpcodes.py
+
+Usage: from httpcodes import codes as http_code
+
+Import into plugin.py and reference curl code message as a standard dict.  I.e.,
+
+    code = curl_code.get('-99', "Unknown code.")
+    self.logger.warning(code)
+
+These codes should allow for more human-friendly logging for users. Unless otherwise stated, the status code is part of
+the HTTP standard (RFC 9110).
+Wikipedia: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
+RFC9110: https://datatracker.ietf.org/doc/html/rfc9110
+
+2023-05-17 DaveL17 Note that these codes and their corresponding error messages were lifted from Wikipedia
+                   dated 2023-05-17.
+"""
+
+codes = {
+    100: "Continue",
+    101: "Switching Protocols",
+    102: "Processing (WebDAV; RFC 2518)",
+    103: "Early Hints (RFC 8297)",
+    200: "OK",
+    201: "Created",
+    202: "Accepted",
+    203: "Non-Authoritative Information (since HTTP/1.1)",
+    204: "No Content",
+    205: "Reset Content",
+    206: "Partial Content",
+    207: "Multi-Status (WebDAV; RFC 4918)",
+    208: "Already Reported (WebDAV; RFC 5842)",
+    226: "IM Used (RFC 3229)",
+    300: "Multiple Choices",
+    301: "Moved Permanently",
+    302: 'Found (Previously "Moved temporarily")',
+    303: "See Other (since HTTP/1.1)",
+    304: "Not Modified",
+    305: "Use Proxy (since HTTP/1.1)",
+    306: "Switch Proxy",
+    307: "Temporary Redirect (since HTTP/1.1)",
+    308: "Permanent Redirect",
+    400: "Bad Request",
+    401: "Unauthorized",
+    402: "Payment Required",
+    403: "Forbidden",
+    404: "Not Found",
+    405: "Method Not Allowed",
+    406: "Not Acceptable",
+    407: "Proxy Authentication Required",
+    408: "Request Timeout",
+    409: "Conflict",
+    410: "Gone",
+    411: "Length Required",
+    412: "Precondition Failed",
+    413: "Payload Too Large",
+    414: "URI Too Long",
+    415: "Unsupported Media Type",
+    416: "Range Not Satisfiable",
+    417: "Expectation Failed",
+    418: "I'm a teapot (RFC 2324, RFC 7168)",
+    421: "Misdirected Request",
+    422: "Unprocessable Entity",
+    423: "Locked (WebDAV; RFC 4918)",
+    424: "Failed Dependency (WebDAV; RFC 4918)",
+    425: "Too Early (RFC 8470)",
+    426: "Upgrade Required",
+    428: "Precondition Required (RFC 6585)",
+    429: "Too Many Requests (RFC 6585)",
+    431: "Request Header Fields Too Large (RFC 6585)",
+    451: "Unavailable For Legal Reasons (RFC 7725)",
+    500: "Internal Server Error",
+    501: "Not Implemented",
+    502: "Bad Gateway",
+    503: "Service Unavailable",
+    504: "Gateway Timeout",
+    505: "HTTP Version Not Supported",
+    506: "Variant Also Negotiates (RFC 2295)",
+    507: "Insufficient Storage (WebDAV; RFC 4918)",
+    508: "Loop Detected (WebDAV; RFC 5842)",
+    510: "Not Extended (RFC 2774)",
+    511: "Network Authentication Required (RFC 6585)",
+}

--- a/Adapters.indigoPlugin/Contents/Server Plugin/indigo_devices_filters.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/indigo_devices_filters.py
@@ -1,0 +1,17 @@
+DEVICE_FILTERS = [
+    "com.somePlugin.devTypeId" 
+    "com.somePlugin",  # all device types defined by some other plugin
+    "indigo.controller",  # include devices that can send commands
+    "indigo.dimmer",  # dimmer devices
+    "indigo.insteon",  # include INSTEON devices - this is an interface filter that can be used with other filters
+    "indigo.iodevice",  # input/output devices
+    "indigo.relay",  # relay devices
+    "indigo.responder",  # include devices whose state can be changed
+    "indigo.sensor",  # all sensor type devices: motion sensors, TriggerLinc, SynchroLinc (sensor devices that have a virtual state in Indigo)
+    "indigo.sprinkler",  # sprinklers
+    "indigo.thermostat",  # thermostats
+    "indigo.x10",  # include X10 devices - this is an interface filter that can be used with other filters
+    "indigo.zwave",  # include Z-Wave devices - this is an interface filter that can be used with other filters
+    "self.devTypeId",  # all devices of type deviceTypeId, where deviceTypeId is one of the device types specified by the calling plugin
+    "self",  # all device types defined by the calling plugin
+]

--- a/Adapters.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -311,7 +311,7 @@ class Plugin(indigo.PluginBase):
         from Tests import test_plugin
         plugin_tests = test_plugin.TestPlugin()
         simple_eval_tests = test_plugin.TestSimpleEval()
-        sensor_adapter_tests = test_plugin.TestSensorAdapter()
+        # sensor_adapter_tests = test_plugin.TestSensorAdapter()
 
         def process_test_result(result, name):
             if result[0] is True:
@@ -323,5 +323,7 @@ class Plugin(indigo.PluginBase):
         process_test_result(test, "Plugin")
         test = simple_eval_tests.test_simple_eval(self)
         process_test_result(test, "Simple Eval")
-        test = sensor_adapter_tests.test_sensor_adapter(self)
-        process_test_result(test, "Sensor Adapter")
+        # test = sensor_adapter_tests.test_sensor_adapter(self)  # There are no sensor adapter tests at this time.
+        # process_test_result(test, "Sensor Adapter")
+        self.logger.warning("There are no Sensor Adapter tests yet.")
+        self.logger.warning("There are no pyrescaler tests yet.")

--- a/Adapters.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -180,7 +180,7 @@ class Plugin(indigo.PluginBase):
             self, _filter: str = "", values_dict: indigo.Dict = None, type_id: str = "", target_id: int = 0
     ) -> list:
         """
-        Docstring placeholder
+        Return a list of device/states with numeric values
 
         :param str _filter:
         :param indigo.Dict values_dict:
@@ -203,9 +203,7 @@ class Plugin(indigo.PluginBase):
         return eligible_sensors
 
     # ==============================================================================
-    def get_scales(
-            self, _filter: str = "", values_dict: indigo.Dict = None, type_id: str = "", target_id: int = 0
-    ) -> list:
+    def get_scales(self, _filter: str = "", values_dict: indigo.Dict = None, type_id: str = "", target_id: int = 0) -> list:
         """
         Docstring placeholder
 
@@ -291,14 +289,39 @@ class Plugin(indigo.PluginBase):
         return values_dict
 
     # ==============================================================================
-    def validate_prefs_config_ui(self, values_dict: indigo.Dict) -> bool:
+    def validate_prefs_config_ui(self, values_dict: indigo.Dict) -> tuple:
         """
         Docstring placeholder
 
         :param indigo.Dict values_dict:
         """
-        self.debug_level = int(values_dict['showDebugLevel'])
-        self.indigo_log_handler.setLevel(self.debug_level)
-        self.sensor_logger.setLevel(self.debug_level)
-        self.pyrescaler_logger.setLevel(self.debug_level)
-        return True
+        error_msg_dict = indigo.Dict()
+        try:
+            self.debug_level = int(values_dict['showDebugLevel'])
+            self.indigo_log_handler.setLevel(self.debug_level)
+            self.sensor_logger.setLevel(self.debug_level)
+            self.pyrescaler_logger.setLevel(self.debug_level)
+            return True, values_dict
+        except TypeError as error:
+            error_msg_dict['showDebugLevel'] = "The debug level is invalid"
+            return False, values_dict, error_msg_dict
+
+    # ==============================================================================
+    def my_tests(self, action=None):
+        from Tests import test_plugin
+        plugin_tests = test_plugin.TestPlugin()
+        simple_eval_tests = test_plugin.TestSimpleEval()
+        sensor_adapter_tests = test_plugin.TestSensorAdapter()
+
+        def process_test_result(result, name):
+            if result[0] is True:
+                self.logger.warning(f"{name} tests passed.")
+            else:
+                self.logger.warning(f"{result[1]}")
+
+        test = plugin_tests.test_plugin(self)
+        process_test_result(test, "Plugin")
+        test = simple_eval_tests.test_simple_eval(self)
+        process_test_result(test, "Simple Eval")
+        test = sensor_adapter_tests.test_sensor_adapter(self)
+        process_test_result(test, "Sensor Adapter")

--- a/Adapters.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -33,7 +33,7 @@ __copyright__ = "Not used."
 __license__   = "Apache 2.0"
 __build__     = "Not used."
 __title__     = 'Adapters Plugin for Indigo'
-__version__   = '2023.2.0'
+__version__   = '2024.1.0'
 
 
 # ==============================================================================
@@ -76,18 +76,12 @@ class Plugin(indigo.PluginBase):
         # =============================== Debug Logging ================================
         self.debug_logging()
 
-        # ============================= Remote Debugging ===============================
-        # try:
-        #     pydevd.settrace('localhost', port=5678, stdoutToServer=True, stderrToServer=True, suspend=False)
-        # except:
-        #     pass
-
         # "Subscribe to Changes" from all indigo devices, so we can update our 'converted' values
         # any time the native value changes.
         indigo.devices.subscribeToChanges()
 
     # ==============================================================================
-    def address_changed(self, values_dict: indigo.Dict = None, type_id: str = "", target_id: int = 0):
+    def address_changed(self, values_dict: indigo.Dict = None, type_id: str = "", target_id: int = 0) -> None:
         """
         Docstring placeholder
 
@@ -98,7 +92,7 @@ class Plugin(indigo.PluginBase):
         self.logger.debug("address_changed")
 
     # ==============================================================================
-    def device_updated(self, orig_dev: indigo.Dict, new_dev: indigo.Dict):
+    def device_updated(self, orig_dev: indigo.Dict, new_dev: indigo.Dict) -> None:
         """
         Docstring placeholder
 
@@ -111,7 +105,7 @@ class Plugin(indigo.PluginBase):
                 adapter.go()
 
     # ==============================================================================
-    def debug_logging(self):
+    def debug_logging(self) -> None:
         """
         The Adapters Plugin logging is minimal due to the fact that the plugin is a shim on top of other objects. For
         example, a sensor changes (which would typically be logged by Indigo or another plugin) so an additional log
@@ -131,7 +125,7 @@ class Plugin(indigo.PluginBase):
         self.pyrescaler_logger.setLevel(self.debug_level)
 
     # ==============================================================================
-    def device_start_comm(self, dev: indigo.Device):
+    def device_start_comm(self, dev: indigo.Device) -> None:
         """
         Docstring placeholder
 
@@ -153,7 +147,7 @@ class Plugin(indigo.PluginBase):
         self.logger.debug(f"added adapter: {new_device.name()}")
 
     # ==============================================================================
-    def device_stop_comm(self, dev: indigo.Device):
+    def device_stop_comm(self, dev: indigo.Device) -> None:
         """
         Docstring placeholder
 
@@ -229,9 +223,7 @@ class Plugin(indigo.PluginBase):
         return opts
 
     # ==============================================================================
-    def open_browser_to_python_format_help(
-            self, values_dict: indigo.Dict = None, type_id: str = "", target_id: int = 0
-    ):
+    def open_browser_to_python_format_help(self, values_dict: indigo.Dict = None, type_id: str = "", target_id: int = 0) -> None:
         """
         Docstring placeholder
 
@@ -242,7 +234,7 @@ class Plugin(indigo.PluginBase):
         self.browserOpen("https://pyformat.info")
 
     # ==============================================================================
-    def scale_type_changed(self, values_dict=None, type_id="", target_id=0):
+    def scale_type_changed(self, values_dict=None, type_id="", target_id=0) -> None:
         """
         Called by Devices.xml when a Predefined Scale Adapter scale type is changed.
         """

--- a/Adapters.indigoPlugin/Contents/Server Plugin/pyrescaler/pyrescaler.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/pyrescaler/pyrescaler.py
@@ -166,6 +166,7 @@ class AffineScaledMeasurement(ScaledMeasurement):
         """
         Docstring placeholder
         """
+        super().__init__()
         self.offset = offset
         self.multiplier = multiplier
         self.format_string = format_string
@@ -193,6 +194,7 @@ class ArbitraryFormulaScaledMeasurement(ScaledMeasurement):
 
     # ==============================================================================
     def __init__(self, formula="x", format_string="{0:.1f}"):
+        super().__init__()
         self.formula = formula
         self.format_string = format_string
 

--- a/Adapters.indigoPlugin/Contents/Server Plugin/requirements.txt
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/requirements.txt
@@ -1,0 +1,1 @@
+python-dotenv==1.0.1

--- a/Adapters.indigoPlugin/Contents/Server Plugin/sensor_adapter.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/sensor_adapter.py
@@ -3,10 +3,7 @@ Docstring placeholder
 """
 import logging
 import indigo  # noqa
-from pyrescaler.pyrescaler import (get_converter,
-                                   AffineScaledMeasurement,
-                                   ArbitraryFormulaScaledMeasurement
-                                   )
+from pyrescaler.pyrescaler import (get_converter, AffineScaledMeasurement, ArbitraryFormulaScaledMeasurement)
 
 
 # ==============================================================================
@@ -42,19 +39,19 @@ class SensorAdapter:
         else:
             self.delegate = _FormulaDelegate(dev, self)
 
-        self.logging.debug(f"new adapter: {self.name()}")
+        self.logging.debug("new adapter: %s " % self.name())
 
         self.go()
 
     # ==============================================================================
-    def name(self):
+    def name(self) -> str:
         """
         Docstring placeholder
         """
         return self.delegate.name()
 
     # ==============================================================================
-    def go(self):
+    def go(self) -> str:
         """
         Docstring placeholder
         """
@@ -70,12 +67,13 @@ class SensorAdapter:
                 decimalPlaces=self.precision,
                 uiValue=converted_txt
             )
-            self.logging.debug(f" {self.name()}  converted to: [ {converted_txt} ]")
+            self.logging.debug(" %s  converted to: [ %s ]" % (self.name(), converted_txt))
 
             return converted_txt
 
         except KeyError:
             pass
+
 
 # ==============================================================================
 class _PredefinedDelegate:
@@ -84,7 +82,7 @@ class _PredefinedDelegate:
     """
 
     # ==============================================================================
-    def __init__(self, dev, adapter):
+    def __init__(self, dev, adapter) -> None:
         """
         Docstring placeholder
 
@@ -113,7 +111,7 @@ class _PredefinedDelegate:
         )
 
     # ==============================================================================
-    def name(self):
+    def name(self) -> str:
         """
         Docstring placeholder
         """
@@ -150,14 +148,11 @@ class _AffineTransformDelegate:
         dev.updateStateImageOnServer(indigo.kStateImageSel.SensorOff)
 
     # ==============================================================================
-    def name(self):
+    def name(self) -> str:
         """
         Docstring placeholder
         """
-        return (
-            f"{self.adapter.native_device_name}['{self.adapter.native_device_state_name}'] "
-            f"{self.format}"
-        )
+        return f"{self.adapter.native_device_name}['{self.adapter.native_device_state_name}'] {self.format}"
 
 
 # ==============================================================================
@@ -185,11 +180,8 @@ class _FormulaDelegate:
         dev.updateStateImageOnServer(indigo.kStateImageSel.SensorOff)
 
     # ==============================================================================
-    def name(self):
+    def name(self) -> str:
         """
         Docstring placeholder
         """
-        return (
-            f"{self.adapter.native_device_name}['{self.adapter.native_device_state_name}'] "
-            f"{self.format}"
-        )
+        return f"{self.adapter.native_device_name}['{self.adapter.native_device_state_name}'] {self.format}"

--- a/Adapters.indigoPlugin/Contents/Server Plugin/sensor_adapter.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/sensor_adapter.py
@@ -74,6 +74,10 @@ class SensorAdapter:
         except KeyError:
             pass
 
+    @staticmethod
+    def foo():
+        return "Foobar"
+
 
 # ==============================================================================
 class _PredefinedDelegate:

--- a/Adapters.indigoPlugin/Contents/Server Plugin/simpleeval.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/simpleeval.py
@@ -73,6 +73,7 @@ You can pass names, operators and functions to the simple_eval function as well:
 """
 
 import ast
+import logging
 import sys
 import operator as op
 from random import random
@@ -83,6 +84,7 @@ from random import random
 MAX_STRING_LENGTH = 100000
 MAX_POWER = 4000000  # highest exponent
 PYTHON3 = sys.version_info[0] == 3
+LOGGER = logging.getLogger("Plugin")
 
 ########################################
 # Exceptions:

--- a/Adapters.indigoPlugin/Contents/Server Plugin/simpleeval.py
+++ b/Adapters.indigoPlugin/Contents/Server Plugin/simpleeval.py
@@ -96,9 +96,7 @@ class InvalidExpression(Exception):
 class FunctionNotDefined(InvalidExpression):
     """ sorry! That function isn't defined! """
     def __init__(self, func_name, expression):
-        self.message = (
-            f"Function '{func_name}' not defined, for expression '{expression}'."
-        )
+        self.message = f"Function '{func_name}' not defined, for expression '{expression}'."
         self.func_name = func_name
         self.expression = expression
 
@@ -171,8 +169,7 @@ def safe_add(a, b):  # pylint: disable=invalid-name
     """ string length limit again """
     if isinstance(a, str) and isinstance(b, str):
         if len(a) + len(b) > MAX_STRING_LENGTH:
-            raise StringTooLong("Sorry, adding those two strings would"
-                                " make a too long string.")
+            raise StringTooLong("Sorry, adding those two strings would make a too long string.")
     return a + b
 
 
@@ -205,7 +202,7 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
     expr = ""
 
     def __init__(self, operators=None, functions=None, names=None):
-        """ Create the evaluator instance.  Set up valid operators (+,-, etc) functions (add,
+        """ Create the evaluator instance.  Set up valid operators (+,-, etc.) functions (add,
         random, get_val, whatever) and names. """
 
         if not operators:
@@ -240,8 +237,7 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
         elif isinstance(node, ast.Str):  # <string>
             if len(node.s) > MAX_STRING_LENGTH:
                 raise StringTooLong(
-                    f"String Literal in statement is too long! ({len(node.s)}, "
-                    f"when {MAX_STRING_LENGTH} is max)"
+                    f"String Literal in statement is too long! ({len(node.s)}, when {MAX_STRING_LENGTH} is max)"
                 )
             return node.s
 
@@ -256,18 +252,14 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
         elif isinstance(node, ast.UnaryOp):  # - and + etc.
             return self.operators[type(node.op)](self._eval(node.operand))
         elif isinstance(node, ast.BinOp):  # <left> <operator> <right>
-            return self.operators[type(node.op)](self._eval(node.left),
-                                                 self._eval(node.right)
-                                                 )
+            return self.operators[type(node.op)](self._eval(node.left), self._eval(node.right))
         elif isinstance(node, ast.BoolOp):  # and & or...
             if isinstance(node.op, ast.And):
                 return all((self._eval(v) for v in node.values))
             elif isinstance(node.op, ast.Or):
                 return any((self._eval(v) for v in node.values))
         elif isinstance(node, ast.Compare):  # 1 < 2, a == b...
-            return self.operators[type(node.ops[0])](self._eval(node.left),
-                                                     self._eval(node.comparators[0])
-                                                     )
+            return self.operators[type(node.ops[0])](self._eval(node.left), self._eval(node.comparators[0]))
         elif isinstance(node, ast.IfExp):  # x if y else z
             return self._eval(node.body) if self._eval(node.test) \
                                          else self._eval(node.orelse)
@@ -294,8 +286,7 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
                     return self.names(node)
                 else:
                     raise InvalidExpression(
-                        f'Trying to use name (variable) "{node.id}" when no "names" defined for '
-                        f'evaluator'
+                        f'Trying to use name (variable) "{node.id}" when no "names" defined for evaluator'
                     )
 
             except KeyError:
@@ -331,9 +322,7 @@ class SimpleEval(object):  # pylint: disable=too-few-public-methods
                 step = self._eval(node.step)
             return slice(lower, upper, step)
         else:
-            raise FeatureNotAvailable(
-                f"Sorry, {type(node).__name__} is not available in this evaluator"
-            )
+            raise FeatureNotAvailable(f"Sorry, {type(node).__name__} is not available in this evaluator")
 
 
 def simple_eval(expr, operators=None, functions=None, names=None):

--- a/_changelog.md
+++ b/_changelog.md
@@ -1,3 +1,8 @@
+### 2024.1.0
+- Removes unneeded PyCharm debugging code.
+- Cleans up .gitignore file.
+- More code typing.
+
 ### 2023.2.0
 - Code refinements.
 - Basic wiki pages.

--- a/_changelog.md
+++ b/_changelog.md
@@ -2,6 +2,7 @@
 - Removes unneeded PyCharm debugging code.
 - Cleans up .gitignore file.
 - More code typing.
+- Unit tests.
 
 ### 2023.2.0
 - Code refinements.

--- a/_to_do_list.md
+++ b/_to_do_list.md
@@ -1,1 +1,1 @@
-### TODO 
+- nothing


### PR DESCRIPTION
This PR adds two types of plugin tests:

- **test_plugin.py** - these tests run against the plugin code itself and many of them rely on the IOM to run successfully. They require a copy of the plugin to be installed and enabled on the active server. Create an action item that calls the hidden `my_tests` action. Complete instructions are in the test file.
- **test_xml.py** - these tests run against all xml files within the `Server Plugin` folder. They do not require a copy of the plugin to be installed or running on the active server. They test for syntax and -- where possible -- allowable values.

Removes unneeded remote debugging code and responds to several code inspection and linting suggestions. In addition, a couple hidden bugs were corrected.

There are no new plugin features included in this PR.